### PR TITLE
Fixes links to idml.io, and https://github.com/IDML/*

### DIFF
--- a/src/main/tut/basic-usage.md
+++ b/src/main/tut/basic-usage.md
@@ -10,7 +10,7 @@ If you want to embed the library in your service, here's a short guide on how to
 
 Here's a simple Java "hello world":
 
-    import com.datasift.ptolemy.*;
+    import io.idml.ptolemy.*;
 
     public class JavaExample {
         public static void main(String[] args) {
@@ -77,7 +77,7 @@ This use case evolved from the interation data model at DataSift where we have r
     PtolemyValue facebookPost = PtolemyJson.parse("{\"message\": \"Some message\"}");
     // Chains can be run just like any other mapping
     PtolemyValue output = facebookMapping.run(facebookPost);
-    
+
 ![chain diagram](./diagrams/chain.png)
 
 ## Mapping Merges

--- a/src/main/tut/dependencies.md
+++ b/src/main/tut/dependencies.md
@@ -28,7 +28,7 @@ The artifacts are published to Maven so you can include it in your project with 
 
 ```xml
 <dependency>
-    <groupId>com.datasift.ptolemy</groupId>
+    <groupId>io.idml</groupId>
     <artifactId>ptolemy-core_2.12</artifactId>
     <version>1.0.xxx</version>
 </dependency>
@@ -39,5 +39,5 @@ The artifacts are published to Maven so you can include it in your project with 
 The dependency can also be managed with SBT:
 
 ```
-libraryDependencies += "com.datasift.ptolemy" %% "ptolemy-core" % "1.0.xxx"
+libraryDependencies += "io.idml.ptolemy" %% "ptolemy-core" % "1.0.xxx"
 ```

--- a/src/main/tut/getting-started.md
+++ b/src/main/tut/getting-started.md
@@ -17,7 +17,7 @@ result = a + b
 
 ## REPL
 
-The REPL is the simplest way to try things out. You can download it from [here](https://github.com/datasift/ptolemy/releases) and then run it with:
+The REPL is the simplest way to try things out. You can download it from [here](https://github.com/IDML/idml/releases) and then run it with:
 
 	java -jar idml-1.0.xxx.jar repl
 
@@ -37,7 +37,7 @@ idml> output = "%s %s".format(a, b)
 
 ## Tool
 
-The IDML tool is the alternative way to evaluate IDML on the command line, it's contained in the same release as the repl from [github releases](https://github.com/datasift/ptolemy/releases).It is invoked on a command line with a set of mappings and will take line-delimited JSON on stdin and map it to stdout:
+The [idml-tool](https://github.com/IDML/idml-tool) is the alternative way to evaluate IDML on the command line. It is invoked on a command line with a set of mappings and will take line-delimited JSON on stdin and map it to stdout:
 
 ### Usage
 
@@ -65,4 +65,3 @@ andi@andi-workstation examples > java -jar idml.jar apply mapping.idml < input.j
 {}
 {}
 ```
-

--- a/src/main/tut/index.md
+++ b/src/main/tut/index.md
@@ -6,8 +6,6 @@ technologies:
  - third: ["Safe", "All actions can fail safely to ensure as much of your data was mapped as possible"]
 ---
 
-
-
 # Overview
 
 IDML is a data preparation language designed to process unstructured data at high volumes.
@@ -21,6 +19,3 @@ IDML is a data preparation language designed to process unstructured data at hig
 * __Extensible__ - Out of the box it has support for things like regular expressions, email and geolocation but it's easy to add new modules
 * __High-performance__ - Built for firehoses
 * __Java-based__ - Integrates with the emerging big data stack, including Hadoop MapReduce and Kafka
-
-
-


### PR DESCRIPTION
Some fixes as a cleanup after the open sourcing:

- fixes package name to io.idml.* rather than com.datasift.*
- Fixes links to github repos https://github.com/IDML/*

I did not test all code examples, so please double check if these work.